### PR TITLE
Actualiza proyectos a .NET 8.0 y añade soporte para consultas de e-NCF 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -262,3 +262,4 @@ __pycache__/
 
 # PublishProfiles
 /DemoNet4XWeb/Properties/PublishProfiles
+/Octetus.ConsultasDgii/Properties/PublishProfiles/FolderProfile.pubxml

--- a/Octetus.ConsultasDgii.WebAPI/Controllers/ConsultasDgiiController.cs
+++ b/Octetus.ConsultasDgii.WebAPI/Controllers/ConsultasDgiiController.cs
@@ -22,23 +22,30 @@ namespace Octetus.ConsultasDgii.WebAPI.Controllers
 
         [HttpPost("consutar-ncf")]
         [Consumes("application/x-www-form-urlencoded")]
-        public RespuestaConsultaNcf ConsultarNcf([FromForm]string ncf, [FromForm] string rnc)
+        public RespuestaConsultaNcf ConsultarNcf([FromForm] string ncf, [FromForm] string rnc)
         {
             return _servicioConsultasDgii.ConsultarNcf(ncf, rnc);
+        }
+
+        [HttpPost("consutar-encf")]
+        [Consumes("application/x-www-form-urlencoded")]
+        public RespuestaConsultaENcf ConsultarENcf(string ncf, string rnc, string rncComprador, string codigoSeg)
+        {
+            return _servicioConsultasDgii.ConsultarENcf(ncf, rnc, rncComprador, codigoSeg);
         }
 
         [HttpPost("consutar-rnc-contribuyente")]
         [Consumes("application/x-www-form-urlencoded")]
         public RespuestaConsultaRncContribuyentes ConsultarRncContribuyentes([FromForm] string rnc)
         {
-            return _servicioConsultasDgii.ConsultarRncContribuyentes( rnc);
+            return _servicioConsultasDgii.ConsultarRncContribuyentes(rnc);
         }
 
         [HttpPost("consutar-rnc-registrados")]
         [Consumes("application/x-www-form-urlencoded")]
         public RespuestaConsultaRncRegistrados ConsultarRncRegistrados([FromForm] string rnc)
         {
-            return _servicioConsultasDgii.ConsultarRncRegistrados( rnc);
+            return _servicioConsultasDgii.ConsultarRncRegistrados(rnc);
         }
     }
 }

--- a/Octetus.ConsultasDgii.WebAPI/Octetus.ConsultasDgii.WebAPI.csproj
+++ b/Octetus.ConsultasDgii.WebAPI/Octetus.ConsultasDgii.WebAPI.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Octetus.ConsultasDgii/Interfaces/IServicioConsultasDgii.cs
+++ b/Octetus.ConsultasDgii/Interfaces/IServicioConsultasDgii.cs
@@ -9,6 +9,8 @@ namespace Octetus.ConsultasDgii.Core.Interfaces
         RespuestaConsultaRncRegistrados ConsultarRncRegistrados(string rnc);
 
         RespuestaConsultaNcf ConsultarNcf(string ncf, string rnc);
+
+        RespuestaConsultaENcf ConsultarENcf(string rncEmisor, string ncf, string rncComprador, string codigoSeg);
     }
 
 }

--- a/Octetus.ConsultasDgii/Messages/RespuestaConsultaENcf.cs
+++ b/Octetus.ConsultasDgii/Messages/RespuestaConsultaENcf.cs
@@ -1,0 +1,20 @@
+﻿namespace Octetus.ConsultasDgii.Core.Messages
+{
+    public class RespuestaConsultaENcf
+    {
+        public string RncEmisor { get; set; }
+        public string RncComprador { get; set; }
+        public string ENcf { get; set; }
+        public string CodigoSeguridad { get; set; }
+        public string Estado { get; set; }
+
+        public decimal MontoTotal	 { get; set; }
+        public decimal TotalITBIS { get; set; }
+        public string FechaEmision	 { get; set; }
+        public string FechaFirma { get; set; }
+        public string Message { get; set; }
+        public bool Success { get; set; }
+    }
+
+
+}

--- a/Octetus.ConsultasDgii/Messages/RespuestaConsultaNcf.cs
+++ b/Octetus.ConsultasDgii/Messages/RespuestaConsultaNcf.cs
@@ -11,6 +11,4 @@
         public string Message { get; set; }
         public bool Success { get; set; }
     }
-
-
 }

--- a/Octetus.ConsultasDgii/Octetus.ConsultasDgii.csproj
+++ b/Octetus.ConsultasDgii/Octetus.ConsultasDgii.csproj
@@ -1,19 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp2.1;net45</TargetFrameworks>
+    <TargetFrameworks>net8.0;net45</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <Version>1.0.0</Version>
   </PropertyGroup>
 
   <ItemGroup>
     <PackageReference Include="HtmlAgilityPack" Version="1.11.24" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <Reference Include="System.Web">
-      <HintPath>..\..\..\..\..\..\..\Program Files (x86)\Reference Assemblies\Microsoft\Framework\.NETFramework\v4.8\System.Web.dll</HintPath>
-    </Reference>
   </ItemGroup>
 
 </Project>

--- a/Octetus.ConsultasDgii/Octetus.ConsultasDgii.csproj
+++ b/Octetus.ConsultasDgii/Octetus.ConsultasDgii.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>net8.0;net45</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Octetus.ConsultasDgii/Services/ServicioConsultasWebDgii.cs
+++ b/Octetus.ConsultasDgii/Services/ServicioConsultasWebDgii.cs
@@ -43,8 +43,8 @@ namespace Octetus.ConsultasDgii.Services
             formData += "__EVENTARGUMENT=&";
             formData += "__VIEWSTATEGENERATOR=" + __VIEWSTATEGENERATOR + "&";
 
-            formData += "__VIEWSTATE=" + HttpUtility.UrlEncode(__VIEWSTATE) + "&";
-            formData += "__EVENTVALIDATION=" + HttpUtility.UrlEncode(__EVENTVALIDATION) + "&";
+            formData += "__VIEWSTATE=" + WebUtility.UrlEncode(__VIEWSTATE) + "&";
+            formData += "__EVENTVALIDATION=" + WebUtility.UrlEncode(__EVENTVALIDATION) + "&";
             formData += "__ASYNCPOST=true&";
             formData += "ctl00$cphMain$btnBuscarCedula=Buscar";
 
@@ -92,8 +92,8 @@ namespace Octetus.ConsultasDgii.Services
             formData += "__EVENTARGUMENT=&";
             formData += "__VIEWSTATEGENERATOR=" + __VIEWSTATEGENERATOR + "&";
 
-            formData += "__VIEWSTATE=" + HttpUtility.UrlEncode(__VIEWSTATE) + "&";
-            formData += "__EVENTVALIDATION=" + HttpUtility.UrlEncode(__EVENTVALIDATION) + "&";
+            formData += "__VIEWSTATE=" + WebUtility.UrlEncode(__VIEWSTATE) + "&";
+            formData += "__EVENTVALIDATION=" + WebUtility.UrlEncode(__EVENTVALIDATION) + "&";
             formData += "__ASYNCPOST=true&";
             formData += "ctl00$cphMain$btnBuscarPorRNC=BUSCAR";
 
@@ -147,9 +147,9 @@ namespace Octetus.ConsultasDgii.Services
             formData += "ctl00$cphMain$txtCodigoSeg=&";
             formData += "__EVENTTARGET=&";
             formData += "__EVENTARGUMENT=&";
-            formData += $"__VIEWSTATE={HttpUtility.UrlEncode(__VIEWSTATE)}&";
+            formData += $"__VIEWSTATE={WebUtility.UrlEncode(__VIEWSTATE)}&";
             formData += $"__VIEWSTATEGENERATOR={__VIEWSTATEGENERATOR}&";
-            formData += $"__EVENTVALIDATION={HttpUtility.UrlEncode(__EVENTVALIDATION)}&";
+            formData += $"__EVENTVALIDATION={WebUtility.UrlEncode(__EVENTVALIDATION)}&";
             formData += "__ASYNCPOST=true&";
             formData += "ctl00$cphMain$btnConsultar=Buscar";
 


### PR DESCRIPTION
Actualiza proyectos a .NET 8.0 y refactorización de la codificación de URL

- Se actualizaron los archivos del proyecto para que apunten a .NET 8.0, reemplazando .NET 5.0 y .NET Core 2.1 que estan fuera de soporte
- Se refactorizó la codificación de URL en ServicioConsultasWebDgii.cs para utilizar WebUtility.UrlEncode en lugar de HttpUtility.UrlEncode.
- Se eliminó la referencia a System.Web para alinearse con las prácticas modernas de .NET.

Agrega soporte para consultas de e-NCF y actualizar archivos del proyecto

- Se agregó el método ConsultarENcf en IServicioConsultasDgii para consultar detalles de e-NCF.
- Se introdujo la clase RespuestaConsultaENcf para encapsular los datos de respuesta de e-NCF.
- Se eliminó la propiedad no utilizada VálidoHasta de RespuestaConsultaNcf.
- Se actualizó la versión del proyecto de 1.0.0 a 1.0.1.
- Se mejoró ServicioConsultasWebDgii con lógica para consultas de e-NCF, incluyendo validación y análisis de respuestas.